### PR TITLE
Escape the SQL string for clipboard

### DIFF
--- a/src/Console/GenerateSqlMigration.php
+++ b/src/Console/GenerateSqlMigration.php
@@ -70,8 +70,8 @@ class GenerateSqlMigration extends BaseCommand
     protected function copyQueriesToClipboard($queries)
     {
         if (`which pbcopy`) {
-            $queriesString = implode("\r\n", $queries);
-            shell_exec("echo '{$queriesString}' | pbcopy");
+            $queriesString = escapeshellarg(implode("\r\n", $queries));
+            shell_exec("echo {$queriesString} | pbcopy");
             $this->info('Copied to clipboard!');
         }
     }


### PR DESCRIPTION
console output is correct. but clipboard dropped brace `'`.

### console output

```
SQL to run '2018_10_03_210000_test' up:
create table `users` (`id` int unsigned not null auto_increment primary key comment 'user id', `name` varchar(255) not null comment 'user name', `example_text` varchar(255) not null default 'none' comment 'example text') default character set utf8 collate utf8_general_ci engine = InnoDB
Copied to clipboard!
```

### clipboard
```sql
create table `users` (`id` int unsigned not null auto_increment primary key comment user id, `name` varchar(255) not null comment user name, `example_text` varchar(255) not null default none comment example text) default character set utf8 collate utf8_general_ci engine = InnoDB
```

### this MR clipboard

```sql
create table `users` (`id` int unsigned not null auto_increment primary key comment 'user id', `name` varchar(255) not null comment 'user name', `example_text` varchar(255) not null default 'none' comment 'example text') default character set utf8 collate utf8_general_ci engine = InnoDB
```
